### PR TITLE
Fix API call for filtering albums by year

### DIFF
--- a/src/components/AlbumsListFilter/AlbumsListFilter.js
+++ b/src/components/AlbumsListFilter/AlbumsListFilter.js
@@ -34,7 +34,7 @@ export default function AlbumsListFilter(props) {
                 Alert.warning("Both year values are required")
             }
             else {
-                props.onFilterChanged({ filter: filter, from: yearFrom, to: yearTo })
+                props.onFilterChanged({ filter: filter, fromYear: yearFrom, toYear: yearTo })
             }
         }
     }


### PR DESCRIPTION
This changes the year filtering parameters from `to`/`from` to `toYear`/`fromYear` as defined in the Subsonic API docs.

~~Note that I haven't tested this, I just saw the error in the version deployed at https://subplayer.netlify.app/ and did some basic searching to track down why it was failing.~~

EDIT: got it building locally and confirmed that the fix works against a local [Supysonic](https://github.com/spl0k/supysonic) v0.7.8 server